### PR TITLE
Add Grafana plugin-validator as a release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,18 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     needs: [package]
 
+  plugin-validator:
+    name: Plugin Validator
+    uses: ./.github/workflows/validate.yml
+    needs: [package]
+    with:
+      node_version: '22'
+
   publish-aws:
     name: Publish to AWS S3
     uses: ./.github/workflows/s3_publish.yml
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    needs: [package, e2e]
+    needs: [package, e2e, plugin-validator]
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,7 +77,7 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     uses: ./.github/workflows/release.yml
-    needs: [package, e2e]
+    needs: [package, e2e, plugin-validator]
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     with:
       version: ${{ needs.package.outputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,7 +70,8 @@ jobs:
           zip $ZIP_NAME $PLUGIN_NAME -r
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "*.zip"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,42 @@
+name: Plugin Validator
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: "Node.js version to use"
+        required: true
+        type: string
+
+jobs:
+  plugin-validator:
+    name: Plugin Validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Set version
+        run: ./.github/scripts/set-version.sh
+
+      - name: Download plugin package
+        uses: actions/download-artifact@v8
+        with:
+          name: plugin-package
+
+      - name: Run plugin-validator
+        run: |
+          ZIP=$(find . -maxdepth 1 -name '*.zip' | head -n 1)
+          if [[ -z "$ZIP" ]]; then
+            echo "No zip file found"
+            exit 1
+          fi
+          echo "Validating $ZIP"
+          npx --yes @grafana/plugin-validator@latest -sourceCodeUri file://. "$ZIP"


### PR DESCRIPTION
Add a reusable validate.yml workflow that runs
@grafana/plugin-validator against the packaged plugin zip, mirroring the checks Grafana runs on submission. Wire it into ci.yml as a plugin-validator job (needs: package) and make publish-aws and create-github-release depend on it, so a failed validation blocks shipping to S3 and cutting a release.