### PR TITLE
HDX-12151: support UUID, IPv4, and IPv6 column types

### DIFF
--- a/openspec/changes/add-uuid-ip-data-types/.openspec.yaml
+++ b/openspec/changes/add-uuid-ip-data-types/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/add-uuid-ip-data-types/design.md
+++ b/openspec/changes/add-uuid-ip-data-types/design.md
@@ -1,0 +1,245 @@
+## Context
+
+`pkg/converters/converters.go` holds a `map[string]Converter` keyed by ClickHouse
+type name; each entry declares a `fieldType` (the `data.Frame` field type), a
+`scanType` (the `database/sql` scan target), and an optional `convert` func that
+defaults to `defaultConvert`. `Converters` flattens the map into
+`[]sqlutil.Converter` at package init.
+
+`sqlutil.MakeScanRow` matches a column's `DatabaseTypeName()` against each
+converter's `InputTypeName`, then its `InputTypeRegex`. On no match it calls
+`sqlutil.NewDefaultConverter`, which inspects the driver's scan type: for `UUID`
+that is `uuid.UUID` (a `[16]byte` array) and for `IPv4`/`IPv6` it is `net.IP`
+(a byte slice). Neither is a valid `data.Frame` field type, so the fallback
+swaps in a `sql.NullString` scan target. `database/sql`'s `convertAssign` has no
+path from an array or a named byte slice into `*string`, so the query fails with
+`unsupported Scan, storing driver.Value type ... into type *string`.
+
+The plugin queries through `database/sql`, not the ClickHouse native API, so the
+driver's per-column `ScanRow` (which does understand `*string`) is bypassed:
+`clickhouse_std.go` `stdRows.Next` fills `[]driver.Value` from
+`column.Row(i, nullable)` and `convertAssign` does the rest. Any design has to
+work with what lands in `driver.Value`.
+
+Constraints: Grafana has no native UUID or IP field type; `sqlutil.FrameConverter`
+documents an aliasing contract (the scan buffer is reused across rows, so a
+converter must never return a pointer into its input); no new dependency should
+be added.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `UUID`, `IPv4`, `IPv6` and their `Nullable(...)` forms return data instead of
+  erroring, as string frame fields.
+- SQL `NULL` in a nullable column reaches the frame as a nil `*string`, so
+  Grafana renders an empty cell rather than a placeholder.
+- UUID/IP columns become eligible ad-hoc filter keys.
+- Coverage at three layers: Go unit, testcontainer integration over both native
+  and HTTP protocols, and Playwright e2e.
+
+**Non-Goals:**
+- A dedicated Grafana field type or display hint for UUID/IP values. They are
+  strings; existing string transformations and panel options apply.
+- `LowCardinality(...)`, `Tuple(...)`, or other wrappers not already supported.
+- IP-aware ad-hoc filter operators (CIDR containment, subnet matching).
+- Changing how `Array(...)` / `Map(...)` columns are converted.
+
+## Decisions
+
+### D1. Render UUID and IP values as string frame fields
+
+`data.FieldType` has no UUID or IP member, and adding a JSON field (as
+`Array()`/`Map()` do) would quote the value and break string transformations,
+sorting, and ad-hoc filter round-tripping. Strings are what every panel, filter,
+and transformation already handles.
+
+*Alternative considered:* map `IPv4` to `FieldTypeUint32` since the driver can
+scan it as one. Rejected — the numeric form is unreadable in a panel and cannot
+be fed back into an ad-hoc filter.
+
+### D2. UUID reuses the existing `String` / `Nullable(String)` mechanism verbatim
+
+`google/uuid`'s `UUID.Value()` implements `driver.Valuer` and returns the textual
+form, and `stdRows.Next` resolves `driver.Valuer` before handing the value to
+`database/sql`. A UUID column therefore already arrives as a `string`. Entries
+for `UUID` and `Nullable(UUID)` reusing the `*string` / `**string` scan types and
+`defaultConvert` are sufficient — no custom converter, no `google/uuid` import in
+`pkg/converters`.
+
+*Alternative considered:* scan into `*uuid.UUID`, which works because
+`*uuid.UUID` implements `sql.Scanner`. Rejected — it adds a direct dependency and
+a parse-then-reformat round trip to reach the same string.
+
+### D3. IP columns scan as `net.IP` and are stringified by dedicated converters
+
+`net.IP` is not a `driver.Valuer`, so the driver value is the raw slice.
+`convertAssign` assigns it into a `*net.IP` target, and reaches `**net.IP` through
+its `reflect.Pointer` recursion (which also yields a nil inner pointer for SQL
+`NULL`). Two converter factories sit alongside the existing `jsonConverter` —
+`ipConverter` for the non-nullable case, `nullableIPConverter` for the nullable
+case, which returns `(*string)(nil)` on NULL and otherwise a freshly allocated
+`*string`. The fresh allocation is what satisfies the `sqlutil.FrameConverter`
+aliasing contract. Both return an error on an unexpected input type rather than
+substituting a zero value, so a driver-behavior change surfaces as a failed query
+instead of silently blank cells.
+
+Each factory takes the renderer for its column type — `ipv4Text` or `ipv6Text`
+(see D5) — so the registry states the type-to-rendering pairing at the point the
+entry is declared, and the nullable and non-nullable variants of a type cannot
+drift apart.
+
+### D4. Match on exact type name; no regex
+
+`converterMatches` tests `InputTypeName` before `InputTypeRegex`, and
+`DatabaseTypeName()` yields exactly `UUID`, `IPv4`, `IPv6`, `Nullable(UUID)`,
+`Nullable(IPv4)`, `Nullable(IPv6)`. No existing regex entry (`^Date\(?`,
+`^Nullable\(Date\(?`, `^Nullable\(String`, `^Array\(.*\)`, `^Map\(.*\)`) matches
+any of those names, so the registry's random map iteration order cannot produce a
+nondeterministic match.
+
+ClickHouse's `INET4` / `INET6` aliases need no separate entries: they are
+case-insensitive aliases in `system.data_type_families`, and the server
+canonicalizes them, so a column declared `INET4` or `inet4` is reported by
+`DESCRIBE` — and therefore by `DatabaseTypeName()` — as `IPv4`. Verified against
+`clickhouse-server:24.8`. There is no plain `IP` type family in ClickHouse
+(`CREATE TABLE t (x IP)` fails with `Unknown data type family: IP`).
+
+### D5. Rendering follows the column type, matching ClickHouse
+
+An `IPv4` column renders dotted-quad; an `IPv6` column renders in IPv6 notation,
+keeping the `::ffff:` prefix for an IPv4-mapped address. That is ClickHouse's own
+rule — formatting is driven by the declared column type, not by the value:
+
+| Column | Stored value      | ClickHouse `toString()` |
+|--------|-------------------|-------------------------|
+| `IPv4` | `1.2.3.4`         | `1.2.3.4`               |
+| `IPv6` | `::ffff:1.2.3.4`  | `::ffff:1.2.3.4`        |
+| `IPv6` | `2001:db8::1`     | `2001:db8::1`           |
+| `IPv6` | `::`              | `::`                    |
+
+Go's `net.IP.String()` is *value*-driven instead: handed the 16 bytes of an
+IPv4-mapped address it prints `1.2.3.4`, discarding the fact that the column is
+IPv6. So the IPv6 path cannot use it. `netip.AddrFrom16(...).String()` can —
+`AddrFrom16` never unmaps, and its output matches the table above exactly.
+
+This matters most on Hydrolix. Hydrolix's own `ip` column type exists only in the
+transform / write schema; at query time it is a native ClickHouse IP type, and
+IPv4 addresses are stored IPv4-mapped. So on Hydrolix the mapped case is the
+*common* case, not an edge case, and value-driven rendering would silently
+disagree with the server on the majority of rows.
+
+Concretely, type-driven rendering buys three things:
+
+1. **One text form per value, across every operator.** A value copied out of a
+   panel cell works as an ad-hoc filter literal under both `=` (which parses the
+   literal) and `=~` / `!~` (which compare `toString(...)` output). Under
+   value-driven rendering the displayed `1.2.3.4` worked under `=` and silently
+   matched nothing under `=~` — a wrong answer, not a cosmetic difference.
+2. **Agreement with every other view of the same data** — `clickhouse-client`,
+   the Hydrolix query UI, `toString()` in a user's own SQL, and any transformation
+   or value mapping a user writes against panel text.
+3. **No information loss.** `::ffff:1.2.3.4` says the value lives in an IPv6
+   column; `1.2.3.4` does not.
+
+*Costs, accepted:* on a Hydrolix cluster whose IP column is mostly IPv4, every
+cell carries an `::ffff:` prefix, which is noisier than dotted-quad for the
+dominant case. Users who prefer the short form can strip the prefix with a
+standard string transformation — the reverse is not possible, because dotted-quad
+has already discarded which family the column holds. Separately, Hydrolix's
+documentation currently states that "Grafana automatically represents IPv4 in
+typical dotted-quad form"; that sentence describes the behavior this decision
+changes and should be updated alongside the release.
+
+*Alternative considered:* keep dotted-quad and make `=~` consistent by rewriting
+the backend's regex branch to parse IP literals. Rejected — it would break the
+operator's documented "match against the rendered text" contract for every other
+column type, and it cannot be done without either unmapping in SQL (lossy for
+genuine IPv6 values) or duplicating Go's formatting rules in ClickHouse
+expressions.
+
+*Not special-cased:* the deprecated IPv4-compatible form (`::1.2.3.4`, no
+`ffff`). ClickHouse prints `::1.2.3.4`, Go prints `::102:304`. RFC 4291
+deprecated that form and ClickHouse cannot distinguish it from any other 16-byte
+value on the way in, so the divergence is documented by a unit test rather than
+worked around.
+
+### D6. Ad-hoc filter eligibility is driven by the frontend supported-type list
+
+`getKeyMap` in `src/editor/metadataProvider.ts` filters DESCRIBE output against
+`SUPPORTED_TYPES` and its derived `NULLABLE_TYPES` / `ARRAY_TYPES` / `MAP_TYPES`
+in `src/constants.ts`. Adding the three base names to `SUPPORTED_TYPES` is the
+whole change; the wrapper lists are derived from it.
+
+`buildFilterCondition` in `pkg/plugin/macros_adhoc.go` emits `key = 'value'` for
+scalar operators and already wraps `=~` / `!~` in `toString(...)`. ClickHouse
+implicitly converts a string literal when comparing against UUID/IPv4/IPv6, so no
+backend macro change is needed — verified against `clickhouse-server:24.8`, where
+each of `uuid_col = '<uuid>'`, `v4_col = '1.2.3.4'`, and `v6_col = '2001:db8::1'`
+returns the matching row.
+
+Two details of that dispatch matter for the newly eligible keys, and both fall
+out correctly without a code change:
+
+- `isString` is `strings.Contains(lower, "string)") || lower == "string"`, so
+  UUID/IP types are *not* strings to it. That is the behaviour we want: the
+  `__null__` sentinel therefore takes the plain `IS NULL` / `IS NOT NULL` branch
+  rather than the string branch, which would also emit `= '__null__'` — a
+  literal no UUID or IP column can parse.
+- The backend's own key set comes from `MetadataProvider.QueryKeys`, which keeps
+  every column DESCRIBE returns without filtering by type. So `SUPPORTED_TYPES`
+  gates only what the *picker offers*; the backend never had an eligibility gap
+  to close. Worth stating explicitly, because a filter whose key misses the key
+  set is skipped and the macro returns `1=1` — a silent widening that looks like
+  success.
+
+### D7. `=` and `=~` agree because rendering agrees — resolved by D5
+
+`=` compares *parsed values*: ClickHouse turns the literal into an IPv6 value and
+compares binary, so `v6_mapped = '1.2.3.4'` matches a stored `::ffff:1.2.3.4`.
+`=~` / `!~` compare *rendered text* via `toString(key) LIKE '...'`.
+
+Those two only agree if the plugin renders a value the same way `toString()`
+does. Under the value-driven rendering originally chosen they did not: the
+displayed `1.2.3.4` matched under `=` and returned nothing under `=~`, with no
+error to indicate why. D5's type-driven rendering removes the divergence — the
+text the panel shows is the text `toString()` produces, so both operator families
+accept it.
+
+A dotted-quad literal still does not match under `=~`, because `=~` is a text
+comparison and the pattern carries no wildcards. That is now a straightforward
+consequence of the operator's contract rather than a trap, since dotted-quad is
+no longer what the panel displays. Both directions are pinned by e2e cases.
+
+## Risks / Trade-offs
+
+- [ClickHouse rejects `uuid_col = '<literal>'` or the IP equivalent, leaving
+  ad-hoc filters broken for the newly eligible keys] → **Resolved.** All three
+  comparisons return the matching row against `clickhouse-server:24.8`, including
+  a dotted-quad literal against an IPv4-mapped `IPv6` column. No branch in
+  `buildFilterCondition` is needed.
+- [Every IPv4 address in a Hydrolix `IPv6` column now displays with an `::ffff:`
+  prefix, which is noisier than dotted-quad for the dominant case] → Accepted per
+  D5, and reversible by the user with a string transformation. Pinned by unit,
+  integration, and e2e tests.
+- [Hydrolix's documentation states Grafana renders IPv4 dotted-quad, which this
+  change contradicts] → Real, and the one item requiring action outside this
+  repo: the doc sentence needs updating alongside the release. No shipped
+  release renders these columns at all, so no dashboard depends on the old
+  behavior.
+- [A future driver bump changes what `IPv6.row()` returns, or drops
+  `uuid.UUID`'s `driver.Valuer`, silently degrading these columns] → The
+  converters error on an unexpected input type instead of returning a zero value,
+  and the testcontainer suite exercises both native and HTTP protocols, so a
+  bump that breaks either surfaces as a red test.
+- [`IPv6.row()` returns a slice into the column's internal block buffer, so the
+  scanned `net.IP` aliases driver-owned memory] → Both converters stringify
+  immediately and never retain the slice, and the returned `*string` is freshly
+  allocated per row, so no frame value outlives the buffer.
+- [A user copies a value from a panel cell and it fails to match under some
+  operator] → **Resolved** by D5: the plugin renders exactly what `toString()`
+  renders, so the copied text works under `=`, `!=`, `=|`, `=~`, and `!~`.
+  Pinned by e2e cases covering `=` and `=~` against the displayed form.
+- [Widening `SUPPORTED_TYPES` grows the derived `ARRAY_TYPES` / `MAP_TYPES` lists
+  and the ad-hoc key picker] → Bounded growth (three base names), and the
+  existing length assertion in `src/editor/metadataProvider.test.ts` keeps the
+  derivation honest.

--- a/openspec/changes/add-uuid-ip-data-types/proposal.md
+++ b/openspec/changes/add-uuid-ip-data-types/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Hydrolix tables expose `UUID`, `IPv4`, and `IPv6` columns, but the plugin has no
+converter for them. `sqlutil.MakeScanRow` falls back to a `sql.NullString` scan
+target that `database/sql` cannot fill from the driver's `uuid.UUID` / `net.IP`
+values, so any query selecting such a column fails outright instead of returning
+data. The same omission hides these columns from the ad-hoc filter key picker.
+
+## What Changes
+
+- Add `UUID`, `IPv4`, `IPv6` and their `Nullable(...)` variants to the plugin's
+  converter registry (`pkg/converters`), rendering each as a string frame field.
+- Extend the frontend supported-type list (`src/constants.ts`) so UUID/IP
+  columns — and their `Nullable`, `Array`, and `Map` wrappers — become eligible
+  ad-hoc filter keys.
+- Seed the ClickHouse e2e fixture with a table carrying UUID/IP columns in both
+  nullable and non-nullable form, populated and NULL.
+- Add Go unit, testcontainer integration, and Playwright e2e coverage.
+- Non-breaking: no existing type mapping, query shape, or dashboard behavior
+  changes. Grafana 10.x dashboards are unaffected.
+
+## Capabilities
+
+### New Capabilities
+- `hdx-column-type-converters`: which ClickHouse column types the plugin maps
+  into Grafana data frames, the frame field type each produces, NULL handling,
+  and which types are eligible as ad-hoc filter keys.
+
+### Modified Capabilities
+
+None. Ad-hoc filter SQL generation, the query models, and the sqlds wrapper keep
+their current requirements.
+
+## Impact
+
+- `pkg/converters/converters.go` — new registry entries and IP-to-text helpers.
+- `src/constants.ts` — supported-type list consumed by `getKeyMap` in
+  `src/editor/metadataProvider.ts`.
+- `testdata/containers/initdb.sql` — new e2e fixture table.
+- `pkg/converters/converters_test.go`, `pkg/plugin/driver_conv_test.go`, and a
+  new Playwright spec under `tests/`.
+- No new dependencies: `net` is stdlib, and `google/uuid` already arrives
+  transitively through the ClickHouse driver.
+- Panels, table views, transformations, and ad-hoc filters all consume UUID/IP
+  columns as strings, so downstream string transformations apply unchanged.

--- a/openspec/changes/add-uuid-ip-data-types/specs/hdx-column-type-converters/spec.md
+++ b/openspec/changes/add-uuid-ip-data-types/specs/hdx-column-type-converters/spec.md
@@ -1,0 +1,196 @@
+## ADDED Requirements
+
+### Requirement: UUID columns convert to string frame fields
+
+The converter registry SHALL map a `UUID` column to a `data.FieldTypeString`
+frame field holding the canonical textual form of the value.
+
+#### Scenario: Non-nullable UUID column is selected
+
+- **WHEN** a query selects a `UUID` column
+- **THEN** the resulting frame field type is `FieldTypeString`
+- **AND** each value is the column's canonical `8-4-4-4-12` hyphenated text
+
+#### Scenario: UUID query no longer fails to scan
+
+- **WHEN** a query selects a `UUID` column over either the native or the HTTP protocol
+- **THEN** frame construction succeeds without a scan error
+
+### Requirement: Nullable UUID columns preserve SQL NULL
+
+The converter registry SHALL map a `Nullable(UUID)` column to a
+`data.FieldTypeNullableString` frame field, and SHALL represent SQL `NULL` as a
+nil `*string`.
+
+#### Scenario: Populated nullable UUID value
+
+- **WHEN** a `Nullable(UUID)` column holds a value
+- **THEN** the frame field's concrete value at that row is the hyphenated text
+
+#### Scenario: NULL nullable UUID value
+
+- **WHEN** a `Nullable(UUID)` column holds SQL `NULL`
+- **THEN** the frame value at that row is nil rather than an empty or placeholder string
+
+### Requirement: IPv4 and IPv6 columns convert to string frame fields
+
+The converter registry SHALL map `IPv4` and `IPv6` columns to
+`data.FieldTypeString` frame fields, rendering each value according to its
+declared column type in the same textual form ClickHouse's own `toString()`
+produces.
+
+#### Scenario: IPv4 column is selected
+
+- **WHEN** a query selects an `IPv4` column holding `1.2.3.4`
+- **THEN** the frame field type is `FieldTypeString` and the value is `1.2.3.4`
+
+#### Scenario: IPv6 column is selected
+
+- **WHEN** a query selects an `IPv6` column holding `2001:db8::1`
+- **THEN** the frame field type is `FieldTypeString` and the value is `2001:db8::1`
+
+#### Scenario: IPv4-mapped address in an IPv6 column
+
+- **WHEN** an `IPv6` column holds a 16-byte IPv4-mapped address such as `::ffff:1.2.3.4`
+- **THEN** the frame value keeps the IPv6 form `::ffff:1.2.3.4`, matching what ClickHouse's `toString()` returns for the same value
+- **AND** it is NOT collapsed to the dotted-quad form `net.IP.String()` would produce
+
+#### Scenario: IPv4-mapped bytes in an IPv4 column
+
+- **WHEN** the same IPv4-mapped 16-byte value reaches the converter for an `IPv4` column
+- **THEN** the frame value is the dotted-quad form `1.2.3.4`, because rendering follows the column type rather than the value
+
+#### Scenario: Rendering is verified against the server rather than a fixture
+
+- **WHEN** an integration test selects an `IPv6` column alongside `toString()` of the same column
+- **THEN** the converted frame value equals the value ClickHouse rendered, over both the native and the HTTP protocol
+
+#### Scenario: Value of an unrenderable length
+
+- **WHEN** a value that is neither 4 nor 16 bytes reaches an IP converter
+- **THEN** it returns a non-nil error and a nil value rather than a partial or blank rendering
+
+### Requirement: Nullable IPv4 and IPv6 columns preserve SQL NULL
+
+The converter registry SHALL map `Nullable(IPv4)` and `Nullable(IPv6)` columns to
+`data.FieldTypeNullableString` frame fields, and SHALL represent SQL `NULL` as a
+nil `*string`.
+
+#### Scenario: Populated nullable IP value
+
+- **WHEN** a `Nullable(IPv4)` or `Nullable(IPv6)` column holds an address
+- **THEN** the frame field's concrete value at that row is that address in text form
+
+#### Scenario: NULL nullable IP value
+
+- **WHEN** a `Nullable(IPv4)` or `Nullable(IPv6)` column holds SQL `NULL`
+- **THEN** the frame value at that row is nil rather than `<nil>` or an empty string
+
+### Requirement: IP converters reject unexpected scan types
+
+The IP converters SHALL return an error when handed a value that is not the
+expected `*net.IP` (non-nullable) or `**net.IP` (nullable) scan target, rather
+than substituting a zero value.
+
+#### Scenario: Converter receives a mismatched type
+
+- **WHEN** an IP converter's `ConverterFunc` is called with a value of any other type
+- **THEN** it returns a non-nil error naming the expected and actual types
+- **AND** it does not return a blank string
+
+### Requirement: Converted IP values do not alias the reused scan buffer
+
+The nullable IP converter SHALL return a freshly allocated `*string` per row, as
+required by the `sqlutil.FrameConverter` aliasing contract.
+
+#### Scenario: Multiple rows of a nullable IP column
+
+- **WHEN** a query returns several rows from a `Nullable(IPv4)` column with distinct addresses
+- **THEN** each frame row holds its own address rather than every row collapsing to the last value
+
+### Requirement: UUID and IP type matching is deterministic
+
+Converter selection SHALL match on exact ClickHouse type name for `UUID`,
+`IPv4`, `IPv6` and their `Nullable(...)` forms, and MUST NOT be reachable by any
+other registry entry's type regex.
+
+#### Scenario: Registry entry lookup
+
+- **WHEN** the registry is searched for `UUID`, `IPv4`, `IPv6`, `Nullable(UUID)`, `Nullable(IPv4)`, or `Nullable(IPv6)`
+- **THEN** exactly one entry matches each name, independent of registry iteration order
+
+### Requirement: UUID and IP columns are eligible ad-hoc filter keys
+
+The frontend supported-type list SHALL include `UUID`, `IPv4`, and `IPv6` so that
+columns of those types — and of their derived `Nullable(...)`, `Array(...)`, and
+`Map(String, ...)` forms — are offered as ad-hoc filter keys.
+
+#### Scenario: DESCRIBE output contains UUID and IP columns
+
+- **WHEN** ad-hoc filter keys are derived from a table describe that includes `UUID`, `IPv4`, `IPv6`, and `Nullable(UUID)` columns
+- **THEN** each of those columns appears in the returned key list with its ClickHouse type
+
+#### Scenario: Derived wrapper type lists stay consistent
+
+- **WHEN** the array and map type lists are derived from the supported-type list
+- **THEN** they contain one entry per supported type and per nullable type, including the UUID and IP entries
+
+### Requirement: Ad-hoc filters on UUID and IP columns produce valid SQL
+
+An ad-hoc filter applied to a `UUID`, `IPv4`, or `IPv6` column SHALL generate a
+condition that ClickHouse accepts and that matches the intended rows.
+
+#### Scenario: Equality filter on a UUID column
+
+- **WHEN** an ad-hoc filter applies `=` with a UUID literal to a `UUID` column
+- **THEN** the generated condition executes without a ClickHouse type error and selects the matching rows
+
+#### Scenario: Equality filter on an IP column
+
+- **WHEN** an ad-hoc filter applies `=` with an address literal to an `IPv4` or `IPv6` column
+- **THEN** the generated condition executes without a ClickHouse type error and selects the matching rows
+
+#### Scenario: Equality filter using the dotted-quad text a panel displays
+
+- **WHEN** an ad-hoc filter applies `=` with `1.2.3.4` to an `IPv6` column holding the IPv4-mapped address `::ffff:1.2.3.4`
+- **THEN** the row matches, because ClickHouse parses the literal into an IPv6 value before comparing
+- **AND** a value copied out of a panel cell is therefore valid ad-hoc filter input
+
+#### Scenario: Negated equality filter on an IP column
+
+- **WHEN** an ad-hoc filter applies `!=` with an address literal to an `IPv4` column
+- **THEN** the generated condition selects every row except the matching one
+
+#### Scenario: Multi-value filter on an IP column
+
+- **WHEN** an ad-hoc filter applies the multi-value operator `=|` with two address literals to an `IPv4` column
+- **THEN** the generated `IN (...)` condition selects the rows matching either literal
+
+#### Scenario: NULL sentinel filter on a nullable UUID or IP column
+
+- **WHEN** an ad-hoc filter applies `=` or `!=` with the `__null__` sentinel to a `Nullable(UUID)`, `Nullable(IPv4)`, or `Nullable(IPv6)` column
+- **THEN** the generated condition is a plain `IS NULL` / `IS NOT NULL` test
+- **AND** it does NOT additionally compare the column against the literal `'__null__'`, which no UUID or IP column can parse
+
+#### Scenario: Regex and LIKE operators accept the displayed value
+
+- **WHEN** an ad-hoc filter applies `=~` or `!~` to a `UUID`, `IPv4`, or `IPv6` column
+- **THEN** the generated condition wraps the column in `toString(...)`
+- **AND** because the plugin renders values in the same form `toString(...)` produces, the text shown in a panel cell matches under `=~` as well as under `=`
+
+#### Scenario: A literal in a different textual form does not match under `=~`
+
+- **WHEN** an ad-hoc filter applies `=~` with the dotted-quad literal `1.2.3.4` to an `IPv6` column rendered as `::ffff:1.2.3.4`
+- **THEN** no rows match, because `=~` compares rendered text and the pattern carries no wildcards
+- **AND** the same literal under `=` does match, because `=` parses the literal before comparing
+
+### Requirement: Ad-hoc filters on UUID and IP columns are not silently dropped
+
+The ad-hoc filter macro SHALL apply a filter whose key names a `UUID`, `IPv4`, or
+`IPv6` column rather than skipping it and falling back to `1=1`.
+
+#### Scenario: Filter key resolves against the table's DESCRIBE key set
+
+- **WHEN** a dashboard applies an ad-hoc filter on a UUID or IP column and the panel query contains `$__adHocFilter()`
+- **THEN** the filter reaches the backend attached to the query
+- **AND** the emitted condition restricts the result set rather than resolving to `1=1`

--- a/openspec/changes/add-uuid-ip-data-types/tasks.md
+++ b/openspec/changes/add-uuid-ip-data-types/tasks.md
@@ -1,0 +1,89 @@
+## 1. Backend converters
+
+- [x] 1.1 Add `ipConverter` to `pkg/converters/converters.go`: assert `*net.IP`, return `ip.String()`, error naming expected and actual types on mismatch
+- [x] 1.2 Add `nullableIPConverter`: assert `**net.IP`, return `(*string)(nil)` when the inner pointer is nil, otherwise a freshly allocated `*string`
+- [x] 1.3 Add `UUID` and `Nullable(UUID)` entries to `convertersMap` using the `*string` / `**string` scan types and `defaultConvert`
+- [x] 1.4 Add `IPv4`, `IPv6`, `Nullable(IPv4)`, `Nullable(IPv6)` entries wired to the two new converters with `FieldTypeString` / `FieldTypeNullableString`
+- [x] 1.5 Confirm `go build ./pkg/...`, `go vet ./...`, and `golangci-lint run` are clean
+
+## 2. Backend unit tests
+
+- [x] 2.1 Add `TestUUID`, `TestNullableUUID`, `TestNullableUUIDShouldBeNil` to `pkg/converters/converters_test.go` following the existing `getConverter` helper style
+- [x] 2.2 Add `TestIPv4` and `TestIPv6` asserting the returned `string` for a 4-byte and a 16-byte `net.IP`
+- [x] 2.3 Add a test pinning the D5 decision: a 16-byte IPv4-mapped `net.IP` in an `IPv6` column converts to the dotted-quad form
+- [x] 2.4 Add `TestNullableIPv4` / `TestNullableIPv6` plus their `...ShouldBeNil` variants asserting `(*string)(nil)`
+- [x] 2.5 Add a test asserting an IP converter errors on a mismatched input type
+- [x] 2.6 Add a test asserting distinct values across several rows do not collapse (aliasing contract)
+- [x] 2.7 Add a test asserting each of the six type names resolves to exactly one registry entry regardless of iteration order
+- [x] 2.8 Run `go test -race ./pkg/converters/`
+
+## 3. Backend integration tests
+
+- [x] 3.1 Add `UUID`, `IPv4`, `IPv6` string entries to `testData` in `pkg/plugin/driver_conv_test.go` so `ConvertersTestSuite` covers them over both native and HTTP
+- [x] 3.2 Run `go test -race ./pkg/plugin/ -run TestConvertersTestSuite` (needs Docker)
+
+## 4. Ad-hoc filter eligibility
+
+- [x] 4.1 Add `"UUID"`, `"IPv4"`, `"IPv6"` to `SUPPORTED_TYPES` in `src/constants.ts`
+- [x] 4.2 Extend the describe mock in `src/__mocks__/tableDescribes.ts` with UUID/IPv4/IPv6/`Nullable(UUID)` columns
+- [x] 4.3 Add a `getKeyMap` unit test in `src/editor/metadataProvider.test.ts` asserting those columns are returned as ad-hoc filter keys
+- [x] 4.4 Confirm the existing `ARRAY_TYPES` length assertion still passes and extend the `toContain` cases to cover `Array(UUID)` / `Array(IPv4)`
+- [x] 4.5 Verify against a live ClickHouse container that `col = '<literal>'` is accepted for UUID, IPv4, and IPv6 columns
+- [ ] 4.6 Only if 4.5 fails: add a UUID/IP branch to the type dispatch in `buildFilterCondition` (`pkg/plugin/macros_adhoc.go`) with cases in `pkg/plugin/macros_adhoc_test.go` — not needed: 4.5 passed against a live `clickhouse/clickhouse-server:24.8` container (all three comparisons returned `count() = 1`)
+- [x] 4.7 Run `npm run typecheck`, `npm run lint`, `npm test -- --ci`
+
+## 5. E2E coverage
+
+- [x] 5.1 Add an `e2e.datatypes` table to `testdata/containers/initdb.sql` with `datetime DateTime64(3, 'UTC')` plus `UUID` / `IPv4` / `IPv6` columns and their nullable counterparts
+- [x] 5.2 Seed two deterministic rows: one fully populated, one with NULLs in every nullable column
+- [x] 5.3 Add `tests/dataTypes.spec.ts` modeled on `tests/macroFunctions.spec.ts`, reusing `tests/helpers.ts`, `tests/dashboardBuilder.ts`, and `tests/queryEditorRow.ts`
+- [x] 5.4 Assert rendered cell text for populated UUID/IP values and empty cells for the NULL row; start every Grafana select locator from `[data-value=""]`
+- [x] 5.5 Run `npm run build`, bring up the stack, and run the suite via the docker-compose `playwright` service
+
+## 5b. E2E coverage for ad-hoc filtering
+
+Added after review: tasks 4.5 and 6.2 only ever checked the filter path by hand
+(a container query and a manual look at the key picker). The runtime path —
+Grafana filter state through `applyTemplateVariables`, over the wire, into
+`$__adHocFilter()`, out as SQL ClickHouse must accept — had no automated
+coverage at any layer. The e2e skill's own audit lists ad-hoc filters (#13) as an
+open gap.
+
+- [x] 5b.1 Add a `v6_mapped IPv6` column to `e2e.datatypes` holding IPv4-mapped addresses, mirroring how Hydrolix stores its `ip` type
+- [x] 5b.2 Add `DashboardBuilder.addAdHocVariable()` so a dashboard can be provisioned with filters already applied, avoiding the three chained react-selects of the filter pill
+- [x] 5b.3 Add `tests/adHocFilterDataTypes.spec.ts` asserting exact row counts and a row fingerprint per filter case, read from the `/api/ds/query` response frames
+- [x] 5b.4 Cover `=` on `UUID` / `IPv4` / `IPv6`, `!=`, the multi-value `=|`, and the `__null__` sentinel on `Nullable(UUID)` / `Nullable(IPv6)`
+- [x] 5b.5 Cover the panel-to-filter round trip: `=` with the dotted-quad text a panel displays matches an IPv4-mapped `IPv6` column
+- [x] 5b.6 Pin the D7 asymmetry: `=~` matches ClickHouse's padded `toString` form and does NOT match the dotted-quad form the panel shows
+- [x] 5b.7 Assert each filter actually reached the backend, so a dropped filter (macro falls back to `1=1`, every row returned) fails rather than passing as a wider result
+- [x] 5b.8 Record in `design.md` (D6, D7) that `isString` correctly excludes UUID/IP from the string NULL branch, and that the backend's `QueryKeys` never type-filtered
+- [x] 5b.9 Verify every expected count against ClickHouse directly, then run both `tests/adHocFilterDataTypes.spec.ts` (11 cases) and `tests/dataTypes.spec.ts` (3 cases) green
+
+## 5c. Align IP rendering with ClickHouse (reverses the original D5)
+
+Raised in review: the original D5 rendered via Go's value-driven
+`net.IP.String()`, so an IPv4-mapped address in an `IPv6` column displayed as
+`1.2.3.4` while ClickHouse renders `::ffff:1.2.3.4`. Since Hydrolix stores IPv4
+mapped, that was the *common* case, and it made a panel value silently
+unmatchable under the `=~` / `!~` operators. Rendering is now type-driven, as
+ClickHouse does it.
+
+- [x] 5c.1 Verify ClickHouse's rendering rule per column type, including `::ffff:0.0.0.0`, `::`, `::1`, and the deprecated `::1.2.3.4` form
+- [x] 5c.2 Verify what the driver hands over per column type — `IPv4` is 4 bytes, `IPv6` is 16 bytes, identical on native and HTTP
+- [x] 5c.3 Confirm `netip.AddrFrom16(...).String()` matches ClickHouse for every case except the deprecated IPv4-compatible form
+- [x] 5c.4 Split the renderer in two: `ipv4Text` (dotted-quad via `To4`) and `ipv6Text` (IPv6 form via `netip.AddrFrom16`)
+- [x] 5c.5 Turn `ipConverter` / `nullableIPConverter` into factories taking a renderer, so the registry pairs each type name with its renderer and the nullable variants cannot drift
+- [x] 5c.6 Return a nil value alongside the error on an unrenderable length, consistent with the mismatched-type branch
+- [x] 5c.7 Update `TestIPv6IPv4MappedAddress` to assert `::ffff:1.2.3.4`, and add `TestIPv4ColumnStaysDottedQuad` proving the same bytes render differently per column type
+- [x] 5c.8 Add `TestIPv6RenderingMatchesClickhouse` pinning the full rendering table, and `TestNullableIPv6IPv4MappedAddress` for the nullable path
+- [x] 5c.9 Add `TestIPv6RenderingMatchesServer` integration test that compares the frame value against the server's own `toString()` over both protocols, so the test cannot drift from ClickHouse
+- [x] 5c.10 Add an e2e case asserting `v6_mapped` renders with the `::ffff:` prefix in a panel
+- [x] 5c.11 Retarget the ad-hoc e2e cases: `=` and `=~` both match the padded form the panel now displays; a dotted-quad literal still matches under `=` and not under `=~`
+- [x] 5c.12 Rewrite D5, fold D7 into it as resolved, and record the accepted costs (verbosity on Hydrolix's IPv4-heavy columns; the Hydrolix doc sentence needs updating)
+- [ ] 5c.13 Update the Hydrolix documentation sentence "Grafana automatically represents IPv4 in typical dotted-quad form" — outside this repo, needs to ship with the release
+
+## 6. Wrap-up
+
+- [x] 6.1 Run the full gate set: `npm run typecheck`, `npm run lint`, `npm test -- --ci`, `go vet ./...`, `golangci-lint run`, `go test -race ./...`
+- [x] 6.2 Manually confirm in Grafana that a `SELECT * FROM e2e.datatypes` table panel renders UUID/IP values, NULL cells are empty, and the columns appear in the ad-hoc filter key picker
+- [x] 6.3 Note in the PR description that IPv4-mapped addresses in `IPv6` columns render dotted-quad, matching Hydrolix's documented Grafana behavior

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -3,6 +3,9 @@ package converters
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/netip"
 	"reflect"
 	"regexp"
 	"time"
@@ -69,6 +72,80 @@ func jsonConverter(in interface{}) (interface{}, error) {
 
 	msg := json.RawMessage(bjson)
 	return &msg, nil
+}
+
+// IP address rendering is driven by the *column type*, not by the value, which
+// is what ClickHouse itself does: an IPv4 column always renders dotted-quad, and
+// an IPv6 column always renders in IPv6 notation — including the "::ffff:"
+// prefix for an IPv4-mapped address. Go's net.IP.String() is value-driven
+// instead and collapses a mapped 16-byte address to dotted-quad, which is why
+// the IPv6 path cannot simply call it (see design decision D5).
+//
+// The registry pairs each type name with the matching renderer, so the mapping
+// holds regardless of how many bytes the driver happens to hand over.
+
+// ipv4Text renders a value from an IPv4 column in dotted-quad form. The driver
+// supplies 4 bytes, but net.ParseIP and friends yield the 16-byte IPv4-mapped
+// encoding, so normalise through To4 rather than assuming a length.
+func ipv4Text(ip net.IP) (string, error) {
+	v4 := ip.To4()
+	if v4 == nil {
+		return "", fmt.Errorf("expected an IPv4 address, got %d bytes (%v)", len(ip), ip)
+	}
+	return v4.String(), nil
+}
+
+// ipv6Text renders a value from an IPv6 column in IPv6 notation, matching
+// ClickHouse's own formatter. netip.Addr is used instead of net.IP because
+// AddrFrom16 never unmaps: an IPv4-mapped address stays "::ffff:1.2.3.4" where
+// net.IP.String() would print "1.2.3.4".
+//
+// A 4-byte input (not something the driver produces for an IPv6 column, but
+// cheap to handle) is widened by To16 into its mapped form, which is exactly
+// how ClickHouse would store and render it in an IPv6 column.
+func ipv6Text(ip net.IP) (string, error) {
+	b := ip.To16()
+	if b == nil {
+		return "", fmt.Errorf("expected an IPv6 address, got %d bytes (%v)", len(ip), ip)
+	}
+	return netip.AddrFrom16([16]byte(b)).String(), nil
+}
+
+// ipConverter builds the ConverterFunc for a non-nullable IP column. The
+// clickhouse driver hands IP columns to database/sql as net.IP, which is not a
+// type data.Frame can hold, so the frame field is a plain string.
+func ipConverter(text func(net.IP) (string, error)) func(in interface{}) (interface{}, error) {
+	return func(in interface{}) (interface{}, error) {
+		ip, ok := in.(*net.IP)
+		if !ok {
+			return nil, fmt.Errorf("ip converter: expected *net.IP, got %T", in)
+		}
+		s, err := text(*ip)
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+}
+
+// nullableIPConverter is ipConverter for Nullable(IPv4)/Nullable(IPv6). NULL
+// arrives as a nil *net.IP and is passed on as a nil *string. The returned
+// pointer is freshly allocated so it never aliases the reused scan buffer.
+func nullableIPConverter(text func(net.IP) (string, error)) func(in interface{}) (interface{}, error) {
+	return func(in interface{}) (interface{}, error) {
+		ip, ok := in.(**net.IP)
+		if !ok {
+			return nil, fmt.Errorf("nullable ip converter: expected **net.IP, got %T", in)
+		}
+		if *ip == nil {
+			return (*string)(nil), nil
+		}
+		s, err := text(**ip)
+		if err != nil {
+			return nil, err
+		}
+		return &s, nil
+	}
 }
 
 // Map of plugin converters
@@ -172,6 +249,36 @@ var convertersMap = map[string]Converter{
 		matchRegex: regexp.MustCompile(`^Nullable\(String`),
 		fieldType:  data.FieldTypeNullableString,
 		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
+	},
+	// uuid.UUID is a driver.Valuer that yields its textual form, so a UUID
+	// column already reaches database/sql as a string.
+	"UUID": {
+		fieldType: data.FieldTypeString,
+		scanType:  reflect.PointerTo(reflect.TypeOf("")),
+	},
+	"Nullable(UUID)": {
+		fieldType: data.FieldTypeNullableString,
+		scanType:  reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
+	},
+	"IPv4": {
+		fieldType: data.FieldTypeString,
+		scanType:  reflect.PointerTo(reflect.TypeOf(net.IP{})),
+		convert:   ipConverter(ipv4Text),
+	},
+	"Nullable(IPv4)": {
+		fieldType: data.FieldTypeNullableString,
+		scanType:  reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(net.IP{}))),
+		convert:   nullableIPConverter(ipv4Text),
+	},
+	"IPv6": {
+		fieldType: data.FieldTypeString,
+		scanType:  reflect.PointerTo(reflect.TypeOf(net.IP{})),
+		convert:   ipConverter(ipv6Text),
+	},
+	"Nullable(IPv6)": {
+		fieldType: data.FieldTypeNullableString,
+		scanType:  reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(net.IP{}))),
+		convert:   nullableIPConverter(ipv6Text),
 	},
 	"Array()": {
 		matchRegex: regexp.MustCompile(`^Array\(.*\)`),

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"net"
 	"testing"
 	"time"
 
@@ -322,4 +323,224 @@ func TestArray(t *testing.T) {
 	msg, err := toJson(value)
 	assert.Nil(t, err)
 	assert.Equal(t, msg, *v.(*json.RawMessage))
+}
+
+func TestUUID(t *testing.T) {
+	value := "61f0c404-5cb3-11e7-907b-a6006ad3dba0"
+	sut := getConverter("UUID")
+	v, err := sut.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, value, actual)
+}
+
+func TestNullableUUID(t *testing.T) {
+	value := "61f0c404-5cb3-11e7-907b-a6006ad3dba0"
+	val := &value
+	sut := getConverter("Nullable(UUID)")
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, value, *actual)
+}
+
+func TestNullableUUIDShouldBeNil(t *testing.T) {
+	var value *string
+	val := &value
+	sut := getConverter("Nullable(UUID)")
+	v, err := sut.FrameConverter.ConverterFunc(val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, value, actual)
+}
+
+func TestIPv4(t *testing.T) {
+	ip := net.ParseIP("1.2.3.4")
+	sut := getConverter("IPv4")
+	v, err := sut.FrameConverter.ConverterFunc(&ip)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, "1.2.3.4", actual)
+}
+
+func TestIPv6(t *testing.T) {
+	ip := net.ParseIP("2001:db8::1")
+	sut := getConverter("IPv6")
+	v, err := sut.FrameConverter.ConverterFunc(&ip)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, "2001:db8::1", actual)
+}
+
+// TestIPv6IPv4MappedAddress pins D5: rendering follows the *column type*, so an
+// IPv4-mapped address in an IPv6 column keeps ClickHouse's "::ffff:" prefix
+// rather than collapsing to the dotted-quad form net.IP.String() would give.
+// This is the dominant case on Hydrolix, which stores IPv4 addresses mapped.
+func TestIPv6IPv4MappedAddress(t *testing.T) {
+	ip := net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}
+	assert.Equal(t, 16, len(ip))
+	// The behaviour being overridden: value-driven formatting loses the prefix.
+	assert.Equal(t, "1.2.3.4", ip.String())
+
+	sut := getConverter("IPv6")
+	v, err := sut.FrameConverter.ConverterFunc(&ip)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, "::ffff:1.2.3.4", actual)
+}
+
+// TestIPv4ColumnStaysDottedQuad is the other half of D5: the *same* mapped bytes
+// in an IPv4 column render dotted-quad, because that is what ClickHouse shows
+// for an IPv4 column. The two converters must not be interchangeable.
+func TestIPv4ColumnStaysDottedQuad(t *testing.T) {
+	ip := net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}
+	sut := getConverter("IPv4")
+	v, err := sut.FrameConverter.ConverterFunc(&ip)
+	assert.Nil(t, err)
+	assert.Equal(t, "1.2.3.4", v.(string))
+}
+
+// TestIPv6RenderingMatchesClickhouse pins the full rendering table against
+// ClickHouse's toString() output, verified on clickhouse-server 24.8 and 25.x.
+// The IPv4-compatible form (::1.2.3.4, no ffff) is the single divergence:
+// ClickHouse prints "::1.2.3.4", Go prints "::102:304". That address form was
+// deprecated by RFC 4291 and ClickHouse cannot store it distinctly from any
+// other 16-byte value, so it is left alone rather than special-cased.
+func TestIPv6RenderingMatchesClickhouse(t *testing.T) {
+	sut := getConverter("IPv6")
+	cases := []struct {
+		ip       net.IP
+		expected string
+	}{
+		{net.ParseIP("2001:db8::1"), "2001:db8::1"},
+		{net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}, "::ffff:1.2.3.4"},
+		{net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0}, "::ffff:0.0.0.0"},
+		{net.IPv6zero, "::"},
+		{net.IPv6loopback, "::1"},
+	}
+	for _, c := range cases {
+		v, err := sut.FrameConverter.ConverterFunc(&c.ip)
+		assert.Nil(t, err)
+		assert.Equal(t, c.expected, v.(string))
+	}
+}
+
+// TestNullableIPv6IPv4MappedAddress: the nullable path must render identically
+// to the non-nullable one. Both variants are wired from the same renderer, and
+// this keeps them from drifting apart.
+func TestNullableIPv6IPv4MappedAddress(t *testing.T) {
+	ip := net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}
+	val := &ip
+	sut := getConverter("Nullable(IPv6)")
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	assert.Equal(t, "::ffff:1.2.3.4", *v.(*string))
+}
+
+// TestIPConverterRejectsWrongLength: a value that is neither 4 nor 16 bytes
+// cannot be rendered, and must error rather than yield "?" or an empty cell.
+func TestIPConverterRejectsWrongLength(t *testing.T) {
+	ip := net.IP{1, 2, 3}
+	for _, name := range []string{"IPv4", "IPv6"} {
+		sut := getConverter(name)
+		v, err := sut.FrameConverter.ConverterFunc(&ip)
+		assert.NotNil(t, err, name)
+		assert.Nil(t, v, name)
+	}
+}
+
+func TestNullableIPv4(t *testing.T) {
+	ip := net.ParseIP("5.6.7.8")
+	val := &ip
+	sut := getConverter("Nullable(IPv4)")
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, "5.6.7.8", *actual)
+}
+
+func TestNullableIPv4ShouldBeNil(t *testing.T) {
+	var ip *net.IP
+	val := &ip
+	sut := getConverter("Nullable(IPv4)")
+	v, err := sut.FrameConverter.ConverterFunc(val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, (*string)(nil), actual)
+}
+
+func TestNullableIPv6(t *testing.T) {
+	ip := net.ParseIP("2001:db8::2")
+	val := &ip
+	sut := getConverter("Nullable(IPv6)")
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, "2001:db8::2", *actual)
+}
+
+func TestNullableIPv6ShouldBeNil(t *testing.T) {
+	var ip *net.IP
+	val := &ip
+	sut := getConverter("Nullable(IPv6)")
+	v, err := sut.FrameConverter.ConverterFunc(val)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, (*string)(nil), actual)
+}
+
+func TestIPConverterMismatchedType(t *testing.T) {
+	sut := getConverter("IPv4")
+	_, err := sut.FrameConverter.ConverterFunc("not-an-ip-pointer")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "*net.IP")
+	assert.Contains(t, err.Error(), "string")
+}
+
+func TestNullableIPConverterMismatchedType(t *testing.T) {
+	sut := getConverter("Nullable(IPv4)")
+	_, err := sut.FrameConverter.ConverterFunc("not-a-double-pointer")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "**net.IP")
+	assert.Contains(t, err.Error(), "string")
+}
+
+// TestNullableIPv4NoAliasing exercises the sqlutil.FrameConverter aliasing
+// contract: the scan buffer is reused across rows, so the returned *string
+// for an earlier row must survive later rows mutating that buffer.
+func TestNullableIPv4NoAliasing(t *testing.T) {
+	sut := getConverter("Nullable(IPv4)")
+	var ptr *net.IP
+	scan := &ptr
+
+	ip1 := net.ParseIP("1.1.1.1")
+	ptr = &ip1
+	v1, err := sut.FrameConverter.ConverterFunc(scan)
+	assert.Nil(t, err)
+	s1 := v1.(*string)
+
+	ip2 := net.ParseIP("2.2.2.2")
+	ptr = &ip2
+	v2, err := sut.FrameConverter.ConverterFunc(scan)
+	assert.Nil(t, err)
+	s2 := v2.(*string)
+
+	assert.Equal(t, "1.1.1.1", *s1)
+	assert.Equal(t, "2.2.2.2", *s2)
+}
+
+// TestUUIDAndIPTypesResolveExactlyOnce pins D4: exact-name matching, no
+// regex reachability, so registry map iteration order can't produce a
+// nondeterministic match for any of these six type names.
+func TestUUIDAndIPTypesResolveExactlyOnce(t *testing.T) {
+	names := []string{"UUID", "Nullable(UUID)", "IPv4", "Nullable(IPv4)", "IPv6", "Nullable(IPv6)"}
+	for _, name := range names {
+		count := 0
+		for _, c := range converters.Converters {
+			if c.Name == name || (c.InputTypeRegex != nil && c.InputTypeRegex.MatchString(name)) {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "expected exactly one converter to match %s", name)
+	}
 }

--- a/pkg/plugin/driver_conv_test.go
+++ b/pkg/plugin/driver_conv_test.go
@@ -45,6 +45,9 @@ var testData = map[string]interface{}{
 	"Bool":     true,
 	"DateTime": dt,
 	"String":   "1234567890",
+	"UUID":     "61f0c404-5cb3-11e7-907b-a6006ad3dba0",
+	"IPv4":     "1.2.3.4",
+	"IPv6":     "2001:db8::1",
 }
 
 func (s *ConvertersTestSuite) TestConverters() {
@@ -93,4 +96,57 @@ func (s *ConvertersTestSuite) TestConverters() {
 		}
 	}
 
+}
+
+// TestIPv6RenderingMatchesServer proves the IPv6 renderer agrees with ClickHouse
+// itself rather than with a string this test hardcoded: it selects the column
+// twice — once raw, once through the server's own toString() — and asserts the
+// converted frame value equals the server's rendering.
+//
+// The value is an IPv4-mapped address, which is how Hydrolix stores IPv4 in its
+// `ip` type, and the case where a value-driven formatter would disagree
+// (net.IP.String() would give "1.2.3.4"). Runs over both protocols because the
+// two take different paths to driver.Value.
+func (s *ConvertersTestSuite) TestIPv6RenderingMatchesServer() {
+	t := s.T()
+	for name, port := range map[string]uint16{"native": s.ChContainer.NativePort, "http": s.ChContainer.HttpPort} {
+		t.Run(name, func(t *testing.T) {
+			settings := s.DatasourceSettings(name, port)
+			db, err := s.HdxPlugin.Connect(s.Ctx, settings, json.RawMessage{})
+			require.NoError(t, err)
+
+			_, err = db.ExecContext(s.Ctx, "drop table if exists ip6_render_test")
+			require.NoError(t, err)
+			_, err = db.ExecContext(s.Ctx,
+				"create table ip6_render_test (v IPv6, n Nullable(IPv6)) engine = MergeTree() order by tuple()")
+			require.NoError(t, err)
+			_, err = db.ExecContext(s.Ctx,
+				"insert into ip6_render_test values ('::ffff:1.2.3.4', '::ffff:1.2.3.4')")
+			require.NoError(t, err)
+
+			// server_text is a String column, so it bypasses the IP converter
+			// entirely and carries ClickHouse's own formatting.
+			rows, err := db.Query("select v, n, toString(v) as server_text from ip6_render_test")
+			require.NoError(t, err)
+
+			frame, err := sqlutil.FrameFromRows(rows, 1, converters.Converters...)
+			require.NoError(t, err)
+			require.Equal(t, 3, len(frame.Fields))
+
+			serverText := frame.Fields[2].At(0)
+			assert.Equal(t, "::ffff:1.2.3.4", serverText,
+				"sanity: ClickHouse should render the mapped address padded")
+
+			assert.Equal(t, serverText, frame.Fields[0].At(0),
+				"IPv6 column should render exactly as ClickHouse renders it")
+
+			concrete, ok := frame.Fields[1].ConcreteAt(0)
+			assert.True(t, ok)
+			assert.Equal(t, serverText, concrete,
+				"Nullable(IPv6) column should render exactly as ClickHouse renders it")
+
+			_, err = db.ExecContext(s.Ctx, "drop table if exists ip6_render_test")
+			require.NoError(t, err)
+		})
+	}
 }

--- a/src/__mocks__/tableDescribes.ts
+++ b/src/__mocks__/tableDescribes.ts
@@ -619,3 +619,42 @@ export const DESCRIBE2 = [
     ttl_expression: "",
   },
 ];
+
+export const DESCRIBE_UUID_IP = [
+  {
+    name: "request_id",
+    type: "UUID",
+    default_type: "",
+    default_expression: "",
+    comment: "",
+    codec_expression: "",
+    ttl_expression: "",
+  },
+  {
+    name: "session_id",
+    type: "Nullable(UUID)",
+    default_type: "",
+    default_expression: "",
+    comment: "",
+    codec_expression: "",
+    ttl_expression: "",
+  },
+  {
+    name: "client_v4",
+    type: "IPv4",
+    default_type: "",
+    default_expression: "",
+    comment: "",
+    codec_expression: "",
+    ttl_expression: "",
+  },
+  {
+    name: "client_v6",
+    type: "IPv6",
+    default_type: "",
+    default_expression: "",
+    comment: "",
+    codec_expression: "",
+    ttl_expression: "",
+  },
+];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,9 @@ export const SUPPORTED_TYPES = [
   "Decimal64",
   "Decimal128",
   "Decimal256",
+  "UUID",
+  "IPv4",
+  "IPv6",
 ];
 
 export const NULLABLE_TYPES = SUPPORTED_TYPES.map((t) => `Nullable(${t})`);

--- a/src/editor/metadataProvider.test.ts
+++ b/src/editor/metadataProvider.test.ts
@@ -3,7 +3,11 @@ import { of } from "rxjs";
 import { getKeyMap, getMetadataProvider } from "./metadataProvider";
 import { setupDataSourceMock } from "../__mocks__/datasource";
 import { adHocTableVariable } from "../__mocks__/variable";
-import { DESCRIBE1, DESCRIBE2 } from "../__mocks__/tableDescribes";
+import {
+  DESCRIBE1,
+  DESCRIBE2,
+  DESCRIBE_UUID_IP,
+} from "../__mocks__/tableDescribes";
 import { ARRAY_TYPES, SUPPORTED_TYPES, NULLABLE_TYPES } from "../constants";
 
 const FUNCTIONS = ["widthBucket", "tupleConcat"];
@@ -51,6 +55,9 @@ describe("ARRAY_TYPES constant", () => {
     expect(ARRAY_TYPES).toContain("Array(Int64)");
     expect(ARRAY_TYPES).toContain("Array(Float32)");
     expect(ARRAY_TYPES).toContain("Array(Float64)");
+    expect(ARRAY_TYPES).toContain("Array(UUID)");
+    expect(ARRAY_TYPES).toContain("Array(IPv4)");
+    expect(ARRAY_TYPES).toContain("Array(IPv6)");
   });
 
   test("should include arrays of nullable types", () => {
@@ -514,6 +521,32 @@ describe("getKeyMap", () => {
           text: "scores",
           type: "Array(Float64)",
           value: "scores",
+        },
+      ],
+    },
+    {
+      name: "uuid and ip types are included",
+      describe: DESCRIBE_UUID_IP,
+      keys: [
+        {
+          text: "request_id",
+          type: "UUID",
+          value: "request_id",
+        },
+        {
+          text: "session_id",
+          type: "Nullable(UUID)",
+          value: "session_id",
+        },
+        {
+          text: "client_v4",
+          type: "IPv4",
+          value: "client_v4",
+        },
+        {
+          text: "client_v6",
+          type: "IPv6",
+          value: "client_v6",
         },
       ],
     },

--- a/testdata/containers/initdb.sql
+++ b/testdata/containers/initdb.sql
@@ -23,3 +23,27 @@ INSERT INTO e2e.macros (datetime, date, v1) VALUES
     ('2025-04-10 00:20:00', '2025-04-10', 2000),
     ('2025-04-10 00:30:00', '2025-04-10', 3000),
     ('2025-04-11 00:00:01', '2025-04-11', -1);
+
+DROP TABLE IF EXISTS e2e.datatypes;
+CREATE TABLE e2e.datatypes
+(
+    datetime  DateTime64(3, 'UTC'),
+    uuid_col  UUID,
+    uuid_null Nullable(UUID),
+    v4_col    IPv4,
+    v4_null   Nullable(IPv4),
+    v6_col    IPv6,
+    v6_null   Nullable(IPv6),
+    -- An IPv6 column holding IPv4-mapped addresses. This mirrors how Hydrolix
+    -- stores its own `ip` transform type: one IPv6 column carrying both
+    -- families, IPv4 padded to ::ffff:a.b.c.d. Rendering is type-driven
+    -- (design decision D5): the plugin keeps the ::ffff: prefix, matching
+    -- ClickHouse's own toString() form, so panel text round-trips into every
+    -- ad-hoc filter operator.
+    v6_mapped IPv6
+) ENGINE = MergeTree() ORDER BY datetime;
+
+INSERT INTO e2e.datatypes (datetime, uuid_col, uuid_null, v4_col, v4_null, v6_col, v6_null, v6_mapped) VALUES
+    ('2025-04-09 00:00:00', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', '1.2.3.4', '1.2.3.4', '2001:db8::1', '2001:db8::1', '::ffff:1.2.3.4');
+INSERT INTO e2e.datatypes (datetime, uuid_col, uuid_null, v4_col, v4_null, v6_col, v6_null, v6_mapped) VALUES
+    ('2025-04-09 00:10:00', '9d3b1f3a-0c2e-4c9a-9a8b-1c2d3e4f5a6b', NULL, '5.6.7.8', NULL, '2001:db8::2', NULL, '::ffff:5.6.7.8');

--- a/tests/adHocFilterDataTypes.spec.ts
+++ b/tests/adHocFilterDataTypes.spec.ts
@@ -1,0 +1,340 @@
+import { test, expect } from "@grafana/plugin-e2e";
+// @ts-ignore
+import {
+  captureRequestsAndResponses,
+  closeWhatsNewDialog,
+  ConfigPageSteps,
+} from "./helpers";
+import { DashboardBuilder } from "./dashboardBuilder";
+
+/**
+ * Runtime ad-hoc filtering over UUID / IPv4 / IPv6 columns.
+ *
+ * Adding UUID/IPv4/IPv6 to SUPPORTED_TYPES made those columns selectable as
+ * ad-hoc filter keys. That is only half the feature: the value the user picks
+ * then has to survive the whole round trip —
+ *
+ *   Grafana filter state
+ *     -> applyTemplateVariables (src/datasource.ts) attaches `filters`
+ *     -> POST /api/ds/query
+ *     -> AdHocFilterMacro (pkg/plugin/macros_adhoc.go) resolves the table from
+ *        the AST and checks the key against the DESCRIBE key set
+ *     -> buildFilterCondition emits SQL
+ *     -> ClickHouse has to accept a *string literal* compared against a
+ *        UUID / IPv4 / IPv6 column
+ *
+ * Nothing above the converter layer was covered before: the eligibility list is
+ * unit-tested (src/editor/metadataProvider.test.ts), the emitted SQL is
+ * unit-tested (pkg/plugin/macros_adhoc_test.go), and the literal comparison was
+ * only ever checked by hand against a container. These tests close that gap.
+ *
+ * Assertions read the /api/ds/query response frames rather than panel DOM.
+ * The panel here is an aggregate, so there is exactly one row to check, and
+ * reading the frame avoids the table-grid column virtualization that forced
+ * tests/dataTypes.spec.ts into two-column queries.
+ *
+ * A silently dropped filter is the failure mode worth naming: if the macro
+ * cannot match the key it skips the filter and returns "1=1", so the query
+ * succeeds and returns *every* row. Every single-row case below would then
+ * report cnt=2, which is why each case asserts an exact count rather than
+ * merely "some rows came back".
+ */
+
+test.describe.configure({ mode: "serial" });
+
+const ADHOC_VAR = "hdx_adhoc";
+const TABLE_VAR = "hdx_table";
+
+/** Both rows of e2e.datatypes, keyed by the UUID that identifies each. */
+const ROW1_UUID = "61f0c404-5cb3-11e7-907b-a6006ad3dba0";
+const ROW2_UUID = "9d3b1f3a-0c2e-4c9a-9a8b-1c2d3e4f5a6b";
+
+/**
+ * count() plus a row fingerprint. min(uuid_col) identifies *which* row matched,
+ * not just how many: a filter that accidentally selected the wrong row would
+ * still report cnt=1. min() over a UUID column is binary-ordered, and
+ * ROW1_UUID < ROW2_UUID, so a two-row match fingerprints as ROW1_UUID.
+ *
+ * Projecting min(uuid_col) also runs the UUID converter over an *aggregate*
+ * result column, whose DatabaseTypeName is still "UUID".
+ */
+const PANEL_SQL =
+  "select count() as cnt, min(uuid_col) as row_uuid " +
+  "from e2e.datatypes where $__adHocFilter()";
+
+interface FilterCase {
+  title: string;
+  key: string;
+  operator: string;
+  value?: string;
+  values?: string[];
+  expectedCount: number;
+  /** Omitted when expectedCount is 0 — min() over no rows is the zero UUID. */
+  expectedRowUuid?: string;
+}
+
+const cases: FilterCase[] = [
+  {
+    title: "UUID column, '=' against a canonical UUID literal",
+    key: "uuid_col",
+    operator: "=",
+    value: ROW1_UUID,
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    title: "IPv4 column, '=' against a dotted-quad literal",
+    key: "v4_col",
+    operator: "=",
+    value: "1.2.3.4",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    title: "IPv6 column, '=' against an IPv6 literal",
+    key: "v6_col",
+    operator: "=",
+    value: "2001:db8::1",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    // The Hydrolix-shaped case, and the panel-to-filter round trip. v6_mapped is
+    // IPv6 holding ::ffff:1.2.3.4, which the plugin renders padded — matching
+    // ClickHouse's own toString() (design decision D5). So this literal is
+    // exactly the text a user copies out of a panel cell.
+    title:
+      "IPv4-mapped IPv6 column, '=' against the padded form the panel displays",
+    key: "v6_mapped",
+    operator: "=",
+    value: "::ffff:1.2.3.4",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    // ClickHouse parses a filter literal into an IPv6 value before comparing, so
+    // a dotted-quad literal still matches a mapped address even though it is no
+    // longer what the panel shows. Kept because it is the form a user typing
+    // from memory would reach for.
+    title:
+      "IPv4-mapped IPv6 column, '=' against a dotted-quad literal is still accepted",
+    key: "v6_mapped",
+    operator: "=",
+    value: "1.2.3.4",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    title: "IPv4 column, '!=' excludes the matching row",
+    key: "v4_col",
+    operator: "!=",
+    value: "1.2.3.4",
+    expectedCount: 1,
+    expectedRowUuid: ROW2_UUID,
+  },
+  {
+    // Multi-value operator -> `key IN ('…','…')`. plugin.json sets
+    // multiValueFilterOperators, so Grafana offers "=|" for these keys.
+    title: "IPv4 column, '=|' with two literals matches both rows",
+    key: "v4_col",
+    operator: "=|",
+    values: ["1.2.3.4", "5.6.7.8"],
+    expectedCount: 2,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    // The __null__ sentinel getTagValues offers for a nullable column. UUID/IP
+    // types are not "string" to buildFilterCondition's isString check, so this
+    // must take the plain `IS NULL` branch — the string branch would also emit
+    // `= '__null__'`, which no UUID column can parse.
+    title: "Nullable(UUID) column, '=' __null__ selects the NULL row",
+    key: "uuid_null",
+    operator: "=",
+    value: "__null__",
+    expectedCount: 1,
+    expectedRowUuid: ROW2_UUID,
+  },
+  {
+    title: "Nullable(UUID) column, '!=' __null__ selects the populated row",
+    key: "uuid_null",
+    operator: "!=",
+    value: "__null__",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    title: "Nullable(IPv6) column, '=' __null__ selects the NULL row",
+    key: "v6_null",
+    operator: "=",
+    value: "__null__",
+    expectedCount: 1,
+    expectedRowUuid: ROW2_UUID,
+  },
+  {
+    // '=~' routes through `toString(key) LIKE '…'` — ClickHouse's own formatter
+    // rather than a parsed comparison. Because the plugin now renders IPv6
+    // columns the same way toString() does, the value copied from a panel cell
+    // works under '=~' as well as under '=' (the pair of cases above and this
+    // one are the whole point of D5: one text form, every operator).
+    title:
+      "IPv4-mapped IPv6 column, '=~' matches the same padded form the panel displays",
+    key: "v6_mapped",
+    operator: "=~",
+    value: "::ffff:1.2.3.4",
+    expectedCount: 1,
+    expectedRowUuid: ROW1_UUID,
+  },
+  {
+    // The boundary that keeps the two operator families honest: '=~' compares
+    // rendered text, so a dotted-quad literal cannot match a column ClickHouse
+    // renders padded (the LIKE pattern carries no wildcards). '=' accepts it
+    // because it parses first. Asserting 0 pins that distinction — if '=~' ever
+    // started parsing IP literals, this test would catch the change.
+    title:
+      "IPv4-mapped IPv6 column, '=~' does not match a dotted-quad literal (text comparison)",
+    key: "v6_mapped",
+    operator: "=~",
+    value: "1.2.3.4",
+    expectedCount: 0,
+  },
+];
+
+/**
+ * Pulls the first frame for the panel query out of a captured /api/ds/query
+ * response. Skips the metadata queries the ad-hoc machinery issues alongside
+ * it by requiring the panel's own SQL on the request side.
+ */
+function findPanelFrame(
+  requests: string[],
+  responses: string[],
+): any | undefined {
+  for (let i = requests.length - 1; i >= 0; i--) {
+    let req: any;
+    try {
+      req = JSON.parse(requests[i]);
+    } catch {
+      continue;
+    }
+    const query = (req?.queries ?? []).find(
+      (q: any) =>
+        typeof q?.rawSql === "string" && q.rawSql.includes("$__adHocFilter()"),
+    );
+    if (!query) continue;
+
+    let resp: any;
+    try {
+      resp = JSON.parse(responses[i]);
+    } catch {
+      continue;
+    }
+    const frames = resp?.results?.[query.refId]?.frames ?? [];
+    if (frames.length) {
+      return { frame: frames[0], query };
+    }
+  }
+  return undefined;
+}
+
+/** Column values of a Grafana JSON data frame, by field name. */
+function columnByName(frame: any, name: string): any[] | undefined {
+  const index = (frame?.schema?.fields ?? []).findIndex(
+    (f: any) => f.name === name,
+  );
+  return index < 0 ? undefined : frame?.data?.values?.[index];
+}
+
+let datasource: { type: string; uid: string };
+
+test.beforeEach(async ({ createDataSourceConfigPage, page }) => {
+  if (datasource !== undefined) {
+    return;
+  }
+  const steps = new ConfigPageSteps(page);
+  const dsConfigPage = await steps.createDatasourceConfigPage(
+    "adhoc datatypes",
+    createDataSourceConfigPage,
+  );
+  await steps.fillTestNativeDatasource();
+
+  // adHocTableVariable names the dashboard variable holding the table whose
+  // columns the key picker offers. The backend macro resolves the table from
+  // the SQL AST independently, so filtering works without it — but production
+  // datasources always set it, and so should the fixture.
+  await steps.configPageLocator
+    .additionalSettingsExpandable()
+    .click({ force: true });
+  await steps.configPageLocator.adHocTableVariable().fill(TABLE_VAR);
+
+  await steps.saveSuccess(dsConfigPage);
+  datasource = dsConfigPage.datasource;
+});
+
+cases.forEach((c) => {
+  test(`ad-hoc filter: ${c.title}`, async ({
+    gotoDashboardPage,
+    page,
+    context,
+  }) => {
+    const { uid } = await new DashboardBuilder(page, datasource)
+      .withTitle(`adhoc-datatypes-${c.key}-${c.operator}-${Date.now()}`)
+      .addCustomVariable({ name: TABLE_VAR, query: "e2e.datatypes" })
+      .addAdHocVariable({
+        name: ADHOC_VAR,
+        filters: [
+          {
+            key: c.key,
+            operator: c.operator,
+            value: c.value,
+            values: c.values,
+          },
+        ],
+      })
+      .addPanel({ title: "adhoc", rawSql: PANEL_SQL })
+      .withTimeRange("2025-04-09T00:00:00.000Z", "2025-04-09T23:59:59.000Z")
+      .create();
+
+    const { requests, responses } = await captureRequestsAndResponses(context);
+
+    const dashboardPage = await gotoDashboardPage({ uid });
+    await closeWhatsNewDialog(page);
+    await dashboardPage.refreshDashboard();
+
+    await expect
+      .poll(() => findPanelFrame(requests, responses) !== undefined, {
+        timeout: 30000,
+      })
+      .toBe(true);
+
+    const { frame, query } = findPanelFrame(requests, responses)!;
+
+    // The filter reached the backend at all. Without this, a frontend-side
+    // regression (filters never attached) would look identical to a backend
+    // one that matched every row.
+    expect(
+      query.filters,
+      "filters should ride along with the panel query",
+    ).toEqual([expect.objectContaining({ key: c.key, operator: c.operator })]);
+
+    // The query itself must not have errored — a literal ClickHouse cannot
+    // parse for the column type surfaces here, not as a wrong row count.
+    expect(
+      frame?.schema,
+      `panel query returned no schema for ${c.key}`,
+    ).toBeTruthy();
+
+    const counts = columnByName(frame, "cnt");
+    expect(counts, "cnt column should be present").toBeTruthy();
+    expect(
+      Number(counts![0]),
+      `filter ${c.key} ${c.operator} ${c.value ?? JSON.stringify(c.values)} ` +
+        `should match ${c.expectedCount} row(s); cnt=2 means the macro dropped ` +
+        `the filter and fell back to 1=1`,
+    ).toBe(c.expectedCount);
+
+    if (c.expectedRowUuid) {
+      const uuids = columnByName(frame, "row_uuid");
+      expect(uuids, "row_uuid column should be present").toBeTruthy();
+      expect(uuids![0], "the wrong row matched").toBe(c.expectedRowUuid);
+    }
+  });
+});

--- a/tests/dashboardBuilder.ts
+++ b/tests/dashboardBuilder.ts
@@ -21,6 +21,22 @@ interface CustomVariableOpts {
     current?: string;
 }
 
+interface AdHocFilterOpts {
+    key: string;
+    /** Grafana ad-hoc operator: "=", "!=", "=~", "!~", "=|", "!=|", … */
+    operator: string;
+    /** Single-value operators read this. */
+    value?: string;
+    /** Multi-value operators ("=|", "!=|") read this instead. */
+    values?: string[];
+}
+
+interface AdHocVariableOpts {
+    name: string;
+    /** Filters the dashboard loads with already applied. */
+    filters?: AdHocFilterOpts[];
+}
+
 interface AnnotationOpts {
     name?: string;
     rawSql: string;
@@ -90,6 +106,42 @@ export class DashboardBuilder {
             })),
             includeAll: false,
             multi: false,
+        });
+        return this;
+    }
+
+    /**
+     * Adds an ad-hoc filter variable bound to this datasource, optionally with
+     * filters already applied.
+     *
+     * Baking the filters into the JSON model rather than driving the on-page
+     * filter pill is deliberate: the pill's key/operator/value selects are
+     * three chained react-selects whose DOM has moved across Grafana 10–13,
+     * and the picker's *eligibility* logic (which columns are offered) is
+     * already unit-tested against SUPPORTED_TYPES in
+     * src/editor/metadataProvider.test.ts. What is untestable at that layer —
+     * and what these filters exercise — is the runtime path: Grafana hands the
+     * filters to applyTemplateVariables, the frontend ships them with the
+     * query, and the backend's $__adHocFilter() macro turns them into SQL that
+     * ClickHouse has to accept.
+     */
+    addAdHocVariable(opts: AdHocVariableOpts): this {
+        this.variables.push({
+            name: opts.name,
+            type: "adhoc",
+            datasource: {type: this.datasource.type, uid: this.datasource.uid},
+            filters: (opts.filters ?? []).map((f) => ({
+                key: f.key,
+                operator: f.operator,
+                // Grafana treats a filter with an empty `value` as incomplete
+                // and drops it before handing filters to the datasource, even
+                // when `values` is populated. Its own multi-value state keeps
+                // `value` set to the first entry, so mirror that — otherwise a
+                // "=|" filter silently never reaches the plugin.
+                value: f.value ?? f.values?.[0] ?? "",
+                ...(f.values ? {values: f.values} : {}),
+                condition: "",
+            })),
         });
         return this;
     }

--- a/tests/dataTypes.spec.ts
+++ b/tests/dataTypes.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, PanelEditPage } from "@grafana/plugin-e2e";
+// @ts-ignore
+import { closeWhatsNewDialog, ConfigPageSteps, queryTextSet } from "./helpers";
+
+/**
+ * Runs sequentially in order to avoid multiple datasource creation.
+ */
+test.describe.configure({ mode: "serial" });
+
+/**
+ * Shared panel page
+ */
+let panelEditPage: PanelEditPage;
+
+/**
+ * Creates one datasource and resets panel page before each test
+ */
+test.beforeEach(async ({ dashboardPage, createDataSourceConfigPage, page }) => {
+  if (panelEditPage === undefined) {
+    const dsConfigPage = await ConfigPageSteps.createDatasourceConfigPage(
+      "dataTypes tests",
+      createDataSourceConfigPage,
+    );
+    const configPageSteps = new ConfigPageSteps(dsConfigPage.ctx.page);
+    await configPageSteps.fillTestNativeDatasource();
+    await configPageSteps.saveSuccess(dsConfigPage);
+  }
+  await dashboardPage.goto();
+  await closeWhatsNewDialog(page);
+  panelEditPage = await dashboardPage.addPanel();
+  await panelEditPage.datasource.set("dataTypes tests");
+  await panelEditPage.toggleTableView();
+});
+
+/**
+ * Selects a non-nullable column alongside its Nullable(...) counterpart.
+ * Kept to two columns per query: the table panel's grid virtualizes columns
+ * that don't fit the editor width, and wider selects (see the 6-column
+ * variant this was split from) silently drop trailing headers/cells from
+ * the DOM, producing a locator-count mismatch that has nothing to do with
+ * converter correctness.
+ */
+[
+  {
+    name: "UUID",
+    col: "uuid_col",
+    nullCol: "uuid_null",
+    value: "61f0c404-5cb3-11e7-907b-a6006ad3dba0",
+  },
+  { name: "IPv4", col: "v4_col", nullCol: "v4_null", value: "1.2.3.4" },
+  { name: "IPv6", col: "v6_col", nullCol: "v6_null", value: "2001:db8::1" },
+].forEach(({ name, col, nullCol, value }) => {
+  test(`${name} columns render as text, NULL renders as an empty cell`, async () => {
+    await queryTextSet(
+      "A",
+      `select ${col}, ${nullCol} from e2e.datatypes order by datetime`,
+      panelEditPage,
+    );
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+
+    // Grafana's table header prepends the field-type icon's accessible name
+    // (e.g. "string") to the column name with no separator in textContent,
+    // so match by substring rather than exact header text.
+    await expect(panelEditPage.panel.fieldNames).toContainText([col, nullCol]);
+
+    // Row 1 (2025-04-09 00:00:00): both columns populated with the same value.
+    await expect(panelEditPage.panel.data).toContainText([value, value]);
+
+    // Row 2 (2025-04-09 00:10:00): the non-nullable column is populated, the
+    // nullable column is SQL NULL and must render as an empty cell rather
+    // than a placeholder string.
+    await expect(panelEditPage.panel.data).not.toContainText(["<nil>"]);
+    await expect(panelEditPage.panel.data).not.toContainText(["null"]);
+  });
+});
+
+/**
+ * The Hydrolix-shaped column: IPv6 holding IPv4-mapped addresses. Rendering
+ * follows the column type, matching ClickHouse's own toString(), so the padded
+ * ::ffff: prefix is preserved rather than collapsed to dotted-quad. Kept as its
+ * own test because v6_mapped has no Nullable counterpart to pair with.
+ */
+test("IPv4-mapped addresses in an IPv6 column keep the ::ffff: prefix", async () => {
+  await queryTextSet(
+    "A",
+    "select v6_mapped, v6_col from e2e.datatypes order by datetime",
+    panelEditPage,
+  );
+  await expect(panelEditPage.refreshPanel()).toBeOK();
+
+  await expect(panelEditPage.panel.fieldNames).toContainText([
+    "v6_mapped",
+    "v6_col",
+  ]);
+  await expect(panelEditPage.panel.data).toContainText([
+    "::ffff:1.2.3.4",
+    "::ffff:5.6.7.8",
+  ]);
+});


### PR DESCRIPTION
## Why

Querying a `UUID`, `IPv4`, or `IPv6` column fails with `unsupported Scan, storing driver.Value type ... into type *string` — the plugin has no converter registry entry for these types, so `sqlutil` falls back to a `sql.NullString` scan target that `database/sql` cannot fill from the driver's `uuid.UUID` / `net.IP` values. The same omission hides these columns from the ad-hoc filter key picker.

Jira: [HDX-12151](https://hydrolix.atlassian.net/browse/HDX-12151)

## What

- **Converter registry** (`pkg/converters`): `UUID`, `IPv4`, `IPv6` and their `Nullable(...)` forms, rendered as string frame fields. SQL `NULL` reaches the frame as a nil `*string`, so panels show an empty cell rather than a placeholder.
- **UUID needs no custom converter**: `uuid.UUID` is a `driver.Valuer` yielding its textual form, so the entries reuse the `String` scan path verbatim — no new dependency.
- **IP rendering is type-driven, matching ClickHouse's own `toString()`**: `IPv4` columns render dotted-quad (`ipv4Text`), `IPv6` columns render in IPv6 notation via `netip.AddrFrom16` (`ipv6Text`) — an IPv4-mapped address keeps its `::ffff:` prefix instead of collapsing to dotted-quad as `net.IP.String()` would.

  Since Hydrolix stores its `ip` transform type as IPv4-mapped `IPv6`, the mapped case is the *common* case. Type-driven rendering keeps panel text identical to `clickhouse-client` output and valid as input for **every** ad-hoc filter operator — including `=~` / `!~`, which compare `toString(...)` text and would silently return zero rows for a dotted-quad literal.
- **Ad-hoc filter eligibility** (`src/constants.ts`): the three base types join `SUPPORTED_TYPES`; the `Nullable`/`Array`/`Map` wrappers derive from it. No backend macro change needed — ClickHouse parses string literals when comparing against these column types (verified), and the `__null__` sentinel correctly takes the plain `IS NULL` branch rather than the string branch, which would also emit `= '__null__'`.

## Testing

- **Go unit** (`pkg/converters`): per-type converter tests; a rendering table pinned against ClickHouse's output (incl. `::`, `::1`, `::ffff:0.0.0.0`); a same-bytes-different-column proof that the two renderers are not interchangeable; aliasing-contract, mismatched-type and unrenderable-length error paths; exactly-one-registry-match determinism.
- **Testcontainer integration** (native + HTTP): round trips for all three types, plus `TestIPv6RenderingMatchesServer`, which selects a column alongside `toString()` of it and asserts the frame equals the server's own rendering — so the test cannot drift from ClickHouse.
- **Playwright e2e**: `tests/dataTypes.spec.ts` (rendering incl. the `::ffff:` prefix, NULL as empty cell) and `tests/adHocFilterDataTypes.spec.ts` (12 filter cases asserting exact row counts plus a row fingerprint, so a silently dropped filter — macro falls back to `1=1`, every row returned — fails instead of passing as a wider result). Adds the `e2e.datatypes` fixture and `DashboardBuilder.addAdHocVariable()`, which closes the long-standing ad-hoc filter gap (#13) in the e2e coverage audit.
- Gates: typecheck, lint, Jest 171/171, `go vet`, `golangci-lint` 0 issues, `go test -race ./...` all green; e2e 17/17.

## Notes

- The Hydrolix docs sentence "Grafana automatically represents IPv4 in typical dotted-quad form" describes the behavior this PR changes and needs updating alongside the release — tracked as the one open task in the OpenSpec change.
- The deprecated IPv4-compatible form (`::1.2.3.4`, no `ffff`) renders as `::102:304` (Go) vs `::1.2.3.4` (ClickHouse). RFC 4291 deprecated it and ClickHouse cannot distinguish it on ingest, so it is documented by a unit test rather than special-cased.
- OpenSpec artifacts are included under `openspec/changes/add-uuid-ip-data-types/`.
- Supersedes #170 (same work, branch renamed to the `HDX-` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HDX-12151]: https://hydrolix.atlassian.net/browse/HDX-12151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ